### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -20,7 +20,7 @@ jobs:
       run: echo "::set-env name=appVersion::$(cat ./hello-world-web-app/package.json | jq '.version')"
       env:
         appVersion: 0.0.1    
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: priyakant/hello-world-web-app-x:${{ appVersion }}
         username: priyakant


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore